### PR TITLE
GTNHfy & reorganize lang file

### DIFF
--- a/src/main/java/vfyjxf/bettercrashes/BetterCrashes.java
+++ b/src/main/java/vfyjxf/bettercrashes/BetterCrashes.java
@@ -1,6 +1,7 @@
 package vfyjxf.bettercrashes;
 
 import cpw.mods.fml.common.Mod;
+import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -15,4 +16,9 @@ public class BetterCrashes {
     public static final String VERSION = "@VERSION@";
     public static final String DEPENDENCIES = "";
     public static final Logger logger = LogManager.getLogger("BetterCrashes");
+
+    @Mod.EventHandler
+    public void preInit(FMLPreInitializationEvent event) {
+        BetterCrashesConfig.init(event.getSuggestedConfigurationFile());
+    }
 }

--- a/src/main/java/vfyjxf/bettercrashes/BetterCrashesConfig.java
+++ b/src/main/java/vfyjxf/bettercrashes/BetterCrashesConfig.java
@@ -5,17 +5,25 @@ import net.minecraftforge.common.config.Configuration;
 
 public class BetterCrashesConfig {
 
-    public static boolean enableUploadCrash = false;
+    public static Configuration config;
 
-    public static void loadConfig(File configFile) {
-        Configuration config = new Configuration(configFile);
-        config.load();
-        enableUploadCrash = config.get(
-                        "upload",
-                        "enableUploadCrash",
-                        false,
-                        "if true,we will use \"https://paste.ubuntu.com\" to upload crash report.")
+    public static final String GENERAL = "General";
+
+    public static boolean isGTNH = true;
+
+    public static void init(File file) {
+        config = new Configuration(file);
+        syncConfig();
+    }
+
+    public static void syncConfig() {
+        config.setCategoryComment(GENERAL, "General config");
+
+        isGTNH = config.get(GENERAL, "isGTNH", true, "Set to false if you're playing outside of GTNH")
                 .getBoolean();
-        config.save();
+
+        if (config.hasChanged()) {
+            config.save();
+        }
     }
 }

--- a/src/main/java/vfyjxf/bettercrashes/BetterCrashesConfig.java
+++ b/src/main/java/vfyjxf/bettercrashes/BetterCrashesConfig.java
@@ -19,7 +19,7 @@ public class BetterCrashesConfig {
     public static void syncConfig() {
         config.setCategoryComment(GENERAL, "General config");
 
-        isGTNH = config.get(GENERAL, "isGTNH", true, "Set to false if you're playing outside of GTNH")
+        isGTNH = config.get(GENERAL, "isGTNH", false, "Set to false if you're playing outside of GTNH")
                 .getBoolean();
 
         if (config.hasChanged()) {

--- a/src/main/java/vfyjxf/bettercrashes/utils/GuiCrashScreen.java
+++ b/src/main/java/vfyjxf/bettercrashes/utils/GuiCrashScreen.java
@@ -6,6 +6,8 @@
 
 package vfyjxf.bettercrashes.utils;
 
+import static vfyjxf.bettercrashes.BetterCrashesConfig.isGTNH;
+
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.client.gui.GuiButton;
@@ -13,9 +15,11 @@ import net.minecraft.client.gui.GuiMainMenu;
 import net.minecraft.client.gui.GuiOptionButton;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.crash.CrashReport;
+import org.apache.commons.lang3.StringUtils;
 
 @SideOnly(Side.CLIENT)
 public class GuiCrashScreen extends GuiProblemScreen {
+
     public GuiCrashScreen(CrashReport report) {
         super(report);
     }
@@ -24,7 +28,12 @@ public class GuiCrashScreen extends GuiProblemScreen {
     public void initGui() {
         super.initGui();
         GuiOptionButton mainMenuButton = new GuiOptionButton(
-                0, width / 2 - 50 - 115, height / 4 + 120 + 12, 110, 20, I18n.format("bettercrashes.gui.toTitle"));
+                0,
+                width / 2 - 50 - 115,
+                height / 4 + 120 + 12,
+                110,
+                20,
+                I18n.format("bettercrashes.gui.crash.toTitle"));
         buttonList.add(mainMenuButton);
     }
 
@@ -37,35 +46,59 @@ public class GuiCrashScreen extends GuiProblemScreen {
     }
 
     @Override
-    public void drawScreen(int mouseX, int mouseY, float partialTicks) { // TODO: localize number of lines
+    public void drawScreen(int mouseX, int mouseY, float partialTicks) {
+        if (detectedUnsupportedModNames == null) {
+            detectedUnsupportedModNames = getUnsupportedMods();
+        }
+        boolean hasUnsupportedMods = !detectedUnsupportedModNames.isEmpty();
+
         drawDefaultBackground();
         drawCenteredString(
-                fontRendererObj, I18n.format("bettercrashes.crashscreen.title"), width / 2, height / 4 - 40, 0xFFFFFF);
+                fontRendererObj,
+                I18n.format("bettercrashes.gui.crash.title"),
+                width / 2,
+                height / 4 - 40 - (hasUnsupportedMods ? 16 : 0),
+                0xFFFFFF);
 
         int textColor = 0xD0D0D0;
         int x = width / 2 - 155;
         int y = height / 4;
+        if (hasUnsupportedMods) {
+            y -= 32;
+        }
 
-        drawString(fontRendererObj, I18n.format("bettercrashes.crashscreen.summary"), x, y, textColor);
-        drawString(fontRendererObj, I18n.format("bettercrashes.crashscreen.paragraph1.line1"), x, y += 18, textColor);
+        drawString(fontRendererObj, I18n.format("bettercrashes.gui.crash.summary"), x, y, textColor);
+        drawString(fontRendererObj, I18n.format("bettercrashes.gui.common.paragraph1"), x, y += 18, textColor);
 
         drawCenteredString(fontRendererObj, getModListString(), width / 2, y += 11, 0xE0E000);
 
-        drawString(fontRendererObj, I18n.format("bettercrashes.crashscreen.paragraph2.line1"), x, y += 11, textColor);
+        drawString(fontRendererObj, I18n.format("bettercrashes.gui.common.paragraph2"), x, y += 11, textColor);
 
         drawCenteredString(
                 fontRendererObj,
                 report.getFile() != null
                         ? "\u00A7n" + report.getFile().getName()
-                        : I18n.format("vanillafix.crashscreen.reportSaveFailed"),
+                        : I18n.format("bettercrashes.gui.common.reportSaveFailed"),
                 width / 2,
                 y += 11,
                 0x00FF00);
 
-        drawString(fontRendererObj, I18n.format("bettercrashes.crashscreen.paragraph3.line1"), x, y += 12, textColor);
-        drawString(fontRendererObj, I18n.format("bettercrashes.crashscreen.paragraph3.line2"), x, y += 9, textColor);
-        drawString(fontRendererObj, I18n.format("bettercrashes.crashscreen.paragraph3.line3"), x, y += 9, textColor);
-        drawString(fontRendererObj, I18n.format("bettercrashes.crashscreen.paragraph3.line4"), x, y += 9, textColor);
+        y += 12;
+        y += drawLongString(
+                fontRendererObj,
+                I18n.format("bettercrashes.gui.common.paragraph3" + (isGTNH ? "_gtnh" : "")),
+                x,
+                y,
+                340,
+                textColor);
+
+        if (hasUnsupportedMods) {
+            drawString(fontRendererObj, I18n.format("bettercrashes.gui.common.paragraph4_gtnh"), x, y += 10, textColor);
+            drawCenteredString(
+                    fontRendererObj, StringUtils.join(detectedUnsupportedModNames, ", "), width / 2, y += 11, 0xE0E000);
+            drawString(fontRendererObj, I18n.format("bettercrashes.gui.common.paragraph5_gtnh"), x, y += 12, textColor);
+        }
+
         super.drawScreen(mouseX, mouseY, partialTicks);
     }
 }

--- a/src/main/java/vfyjxf/bettercrashes/utils/GuiInitErrorScreen.java
+++ b/src/main/java/vfyjxf/bettercrashes/utils/GuiInitErrorScreen.java
@@ -6,11 +6,14 @@
 
 package vfyjxf.bettercrashes.utils;
 
+import static vfyjxf.bettercrashes.BetterCrashesConfig.isGTNH;
+
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.crash.CrashReport;
+import org.apache.commons.lang3.StringUtils;
 
 @SideOnly(Side.CLIENT)
 public class GuiInitErrorScreen extends GuiProblemScreen {
@@ -24,14 +27,19 @@ public class GuiInitErrorScreen extends GuiProblemScreen {
         mc.setIngameNotInFocus();
         buttonList.clear();
         buttonList.add(new GuiButton(
-                1, width / 2 - 155, height / 4 + 120 + 12, 150, 20, I18n.format("bettercrashes.gui.openCrashReport")));
+                1,
+                width / 2 - 155,
+                height / 4 + 120 + 12,
+                150,
+                20,
+                I18n.format("bettercrashes.gui.common.openCrashReport")));
         buttonList.add(new GuiButton(
                 2,
                 width / 2 - 155 + 160,
                 height / 4 + 120 + 12,
                 150,
                 20,
-                I18n.format("bettercrashes.gui.uploadReportAndCopyLink")));
+                I18n.format("bettercrashes.gui.common.uploadReportAndCopyLink")));
     }
 
     @Override
@@ -40,43 +48,59 @@ public class GuiInitErrorScreen extends GuiProblemScreen {
     }
 
     @Override
-    public void drawScreen(int mouseX, int mouseY, float partialTicks) { // TODO: localize number of lines
+    public void drawScreen(int mouseX, int mouseY, float partialTicks) {
+        if (detectedUnsupportedModNames == null) {
+            detectedUnsupportedModNames = getUnsupportedMods();
+        }
+        boolean hasUnsupportedMods = !detectedUnsupportedModNames.isEmpty();
+
         drawDefaultBackground();
         drawCenteredString(
                 fontRendererObj,
-                I18n.format("bettercrashes.initerrorscreen.title"),
+                I18n.format("bettercrashes.gui.init_error.title"),
                 width / 2,
-                height / 4 - 40,
+                height / 4 - 40 - (hasUnsupportedMods ? 16 : 0),
                 0xFFFFFF);
 
         int textColor = 0xD0D0D0;
         int x = width / 2 - 155;
         int y = height / 4;
+        if (hasUnsupportedMods) {
+            y -= 32;
+        }
 
-        drawString(fontRendererObj, I18n.format("bettercrashes.initerrorscreen.summary"), x, y, textColor);
-        drawString(fontRendererObj, I18n.format("bettercrashes.crashscreen.paragraph1.line1"), x, y += 18, textColor);
+        drawString(fontRendererObj, I18n.format("bettercrashes.gui.init_error.summary"), x, y, textColor);
+        drawString(fontRendererObj, I18n.format("bettercrashes.gui.common.paragraph1"), x, y += 18, textColor);
 
         drawCenteredString(fontRendererObj, getModListString(), width / 2, y += 11, 0xE0E000);
 
-        drawString(fontRendererObj, I18n.format("bettercrashes.crashscreen.paragraph2.line1"), x, y += 11, textColor);
+        drawString(fontRendererObj, I18n.format("bettercrashes.gui.common.paragraph2"), x, y += 11, textColor);
 
         drawCenteredString(
                 fontRendererObj,
                 report.getFile() != null
                         ? "\u00A7n" + report.getFile().getName()
-                        : I18n.format("vanillafix.crashscreen.reportSaveFailed"),
+                        : I18n.format("bettercrashes.gui.common.reportSaveFailed"),
                 width / 2,
                 y += 11,
                 0x00FF00);
 
-        drawString(
-                fontRendererObj, I18n.format("bettercrashes.initerrorscreen.paragraph3.line1"), x, y += 12, textColor);
-        drawString(
-                fontRendererObj, I18n.format("bettercrashes.initerrorscreen.paragraph3.line2"), x, y += 9, textColor);
-        drawString(
-                fontRendererObj, I18n.format("bettercrashes.initerrorscreen.paragraph3.line3"), x, y += 9, textColor);
-        drawString(
-                fontRendererObj, I18n.format("bettercrashes.initerrorscreen.paragraph3.line4"), x, y += 9, textColor);
+        y += 12;
+        y += drawLongString(
+                fontRendererObj,
+                I18n.format("bettercrashes.gui.common.paragraph3" + (isGTNH ? "_gtnh" : "")),
+                x,
+                y,
+                340,
+                textColor);
+
+        if (hasUnsupportedMods) {
+            drawString(fontRendererObj, I18n.format("bettercrashes.gui.common.paragraph4_gtnh"), x, y += 10, textColor);
+            drawCenteredString(
+                    fontRendererObj, StringUtils.join(detectedUnsupportedModNames, ", "), width / 2, y += 11, 0xE0E000);
+            drawString(fontRendererObj, I18n.format("bettercrashes.gui.common.paragraph5_gtnh"), x, y += 12, textColor);
+        }
+
         super.drawScreen(mouseX, mouseY, partialTicks);
     }
 }

--- a/src/main/java/vfyjxf/bettercrashes/utils/GuiProblemScreen.java
+++ b/src/main/java/vfyjxf/bettercrashes/utils/GuiProblemScreen.java
@@ -6,18 +6,28 @@
 
 package vfyjxf.bettercrashes.utils;
 
+import cpw.mods.fml.client.FMLClientHandler;
+import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.ModContainer;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import java.awt.*;
 import java.io.IOException;
+import java.net.URI;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.crash.CrashReport;
 import org.apache.commons.lang3.StringUtils;
+import vfyjxf.bettercrashes.BetterCrashes;
+import vfyjxf.bettercrashes.BetterCrashesConfig;
 
 @SideOnly(Side.CLIENT)
 public abstract class GuiProblemScreen extends GuiScreen {
@@ -25,6 +35,10 @@ public abstract class GuiProblemScreen extends GuiScreen {
     protected final CrashReport report;
     private String hasteLink = null;
     private String modListString;
+    protected static final List<String> UNSUPPORTED_MOD_IDS = Arrays.asList();
+    protected List<String> detectedUnsupportedModNames;
+    private static final String GTNH_ISSUE_TRACKER =
+            "https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/labels/Type%3A%20Crash";
 
     public GuiProblemScreen(CrashReport report) {
         this.report = report;
@@ -35,14 +49,28 @@ public abstract class GuiProblemScreen extends GuiScreen {
         mc.setIngameNotInFocus();
         buttonList.clear();
         buttonList.add(new GuiButton(
-                1, width / 2 - 50, height / 4 + 120 + 12, 110, 20, I18n.format("bettercrashes.gui.openCrashReport")));
+                1,
+                width / 2 - 50,
+                height / 4 + 120 + 12,
+                110,
+                20,
+                I18n.format("bettercrashes.gui.common.openCrashReport")));
         buttonList.add(new GuiButton(
                 2,
                 width / 2 - 50 + 115,
                 height / 4 + 120 + 12,
                 110,
                 20,
-                I18n.format("bettercrashes.gui.uploadReportAndCopyLink")));
+                I18n.format("bettercrashes.gui.common.uploadReportAndCopyLink")));
+        if (BetterCrashesConfig.isGTNH) {
+            buttonList.add(new GuiButton(
+                    3,
+                    width / 2 - 50 - 15,
+                    height / 4 + 120 + 12 + 25,
+                    140,
+                    20,
+                    I18n.format("bettercrashes.gui.common.gtnhIssueTracker")));
+        }
     }
 
     @Override
@@ -51,7 +79,7 @@ public abstract class GuiProblemScreen extends GuiScreen {
             try {
                 CrashUtils.openCrashReport(report);
             } catch (IOException e) {
-                button.displayString = I18n.format("bettercrashes.gui.failed");
+                button.displayString = I18n.format("bettercrashes.gui.common.failed");
                 button.enabled = false;
                 e.printStackTrace();
             }
@@ -62,12 +90,23 @@ public abstract class GuiProblemScreen extends GuiScreen {
                     hasteLink = CrashReportUpload.uploadToUbuntuPastebin(
                             "https://paste.ubuntu.com", report.getCompleteReport());
                 } catch (IOException e) {
-                    button.displayString = I18n.format("bettercrashes.gui.failed");
+                    button.displayString = I18n.format("bettercrashes.gui.common.failed");
                     button.enabled = false;
                     e.printStackTrace();
                 }
             }
             setClipboardString(hasteLink);
+        }
+        if (button.id == 3) {
+            if (!Desktop.isDesktopSupported()) {
+                BetterCrashes.logger.error("Desktop is not supported");
+                return;
+            }
+            try {
+                Desktop.getDesktop().browse(new URI(GTNH_ISSUE_TRACKER));
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
         }
     }
 
@@ -78,18 +117,43 @@ public abstract class GuiProblemScreen extends GuiScreen {
         if (modListString == null) {
             final Set<ModContainer> suspectedMods = ((IPatchedCrashReport) report).getSuspectedMods();
             if (suspectedMods == null) {
-                return modListString = I18n.format("bettercrashes.crashscreen.identificationErrored");
+                return modListString = I18n.format("bettercrashes.gui.common.identificationErrored");
             }
             List<String> modNames = new ArrayList<>();
             for (ModContainer mod : suspectedMods) {
                 modNames.add(mod.getName());
             }
             if (modNames.isEmpty()) {
-                modListString = I18n.format("bettercrashes.crashscreen.unknownCause");
+                modListString = I18n.format("bettercrashes.gui.common.unknownCause");
             } else {
                 modListString = StringUtils.join(modNames, ", ");
             }
         }
         return modListString;
+    }
+
+    protected int drawLongString(FontRenderer fontRenderer, String text, int x, int y, int width, int color) {
+        int yOffset = 0;
+        for (Object line : Minecraft.getMinecraft().fontRenderer.listFormattedStringToWidth(text, width)) {
+            drawString(fontRenderer, (String) line, x, y + yOffset, color);
+            yOffset += 9;
+        }
+        return yOffset;
+    }
+
+    protected List<String> getUnsupportedMods() {
+        if (!BetterCrashesConfig.isGTNH) {
+            return Collections.emptyList();
+        }
+        List<String> list = new ArrayList<>();
+        for (ModContainer mod : Loader.instance().getModList()) {
+            if (UNSUPPORTED_MOD_IDS.contains(mod.getModId())) {
+                list.add(mod.getName());
+            }
+        }
+        if (FMLClientHandler.instance().hasOptifine()) {
+            list.add("Optifine");
+        }
+        return list;
     }
 }

--- a/src/main/resources/assets/bettercrashes/lang/en_US.lang
+++ b/src/main/resources/assets/bettercrashes/lang/en_US.lang
@@ -1,23 +1,21 @@
-bettercrashes.gui.uploadReportAndCopyLink=Upload and copy link
-bettercrashes.gui.openCrashReport=Open Crash Report
-bettercrashes.gui.failed=[Failed]
-bettercrashes.crashscreen.identificationErrored=[Error identifying]
-bettercrashes.crashscreen.unknownCause=Unknown
-bettercrashes.gui.toTitle=Return to main menu
+bettercrashes.gui.crash.toTitle=Return to main menu
+bettercrashes.gui.common.uploadReportAndCopyLink=Upload and copy link
+bettercrashes.gui.common.openCrashReport=Open Crash Report
+bettercrashes.gui.common.failed=[Failed]
+bettercrashes.gui.common.gtnhIssueTracker=Open GTNH issue tracker
 
-bettercrashes.crashscreen.title=Minecraft crashed!
-bettercrashes.crashscreen.summary=Minecraft ran into a problem and crashed.
-bettercrashes.crashscreen.paragraph1.line1=The following mod(s) have been identified as potential causes:
-bettercrashes.crashscreen.paragraph2.line1=report has been generated, and click the button below to open:
-bettercrashes.crashscreen.paragraph3.line1=You're encouraged to send this report's link to the mod's author to help
-bettercrashes.crashscreen.paragraph3.line2=them fix the issue, click the "Upload and Copy link" can upload report
-bettercrashes.crashscreen.paragraph3.line3=and copy its link to clipboard. Since BetterCrashes is installed, you
-bettercrashes.crashscreen.paragraph3.line4=can keep playing despite the crash.
+bettercrashes.gui.common.paragraph1=The following mod(s) have been identified as potential causes:
+bettercrashes.gui.common.identificationErrored=[Error identifying]
+bettercrashes.gui.common.unknownCause=Unknown
+bettercrashes.gui.common.paragraph2=report has been generated, and click the button below to open:
+bettercrashes.gui.common.reportSaveFailed=[Error saving report, see log]
+bettercrashes.gui.common.paragraph3=You're encouraged to send this report's link to the mod's author to help them fix the issue. Clicking the "Upload and Copy link" button can upload report and copy its link to clipboard. Since BetterCrashes is installed, you can keep playing despite the crash.
+bettercrashes.gui.common.paragraph3_gtnh=You're encouraged to send this report's link to the GTNH issue tracker to help us fix the issue, AFTER searching the tracker for similar issue already reported. Clicking the "Upload and Copy link" button can upload report and copy its link to clipboard. Since BetterCrashes is installed, you can keep playing despite the crash.
+bettercrashes.gui.common.paragraph4_gtnh=GTNH does not support the following mod(s):
+bettercrashes.gui.common.paragraph5_gtnh=When sending report, add mention to these as well.
 
-bettercrashes.initerrorscreen.title=Minecraft failed to start!
-bettercrashes.initerrorscreen.summary=An error during startup prevented Minecraft from starting.
-bettercrashes.initerrorscreen.paragraph2.line1=report has been generated, and click the button below to open:
-bettercrashes.initerrorscreen.paragraph3.line1=You're encouraged to send this report's link to the mod's author to help
-bettercrashes.initerrorscreen.paragraph3.line2=them fix the issue, click the "Upload and Copy link" can upload report
-bettercrashes.initerrorscreen.paragraph3.line3=and copy its link to clipboard. Since BetterCrashes is installed, you
-bettercrashes.initerrorscreen.paragraph3.line4=can keep playing despite the crash.
+bettercrashes.gui.crash.title=Minecraft crashed!
+bettercrashes.gui.crash.summary=Minecraft ran into a problem and crashed.
+
+bettercrashes.gui.init_error.title=Minecraft failed to start!
+bettercrashes.gui.init_error.summary=An error during startup prevented Minecraft from starting.

--- a/src/main/resources/assets/bettercrashes/lang/zh_CN.lang
+++ b/src/main/resources/assets/bettercrashes/lang/zh_CN.lang
@@ -1,24 +1,22 @@
-bettercrashes.gui.uploadReportAndCopyLink=上传并复制链接
-bettercrashes.gui.openCrashReport=打开崩溃报告
-bettercrashes.gui.failed=[失败]
-bettercrashes.crashscreen.identificationErrored=[鉴别错误]
-bettercrashes.crashscreen.unknownCause=未知
-bettercrashes.gui.toTitle=回到主菜单
+bettercrashes.gui.crash.toTitle=回到主菜单
+bettercrashes.gui.common.uploadReportAndCopyLink=上传并复制链接
+bettercrashes.gui.common.openCrashReport=打开崩溃报告
+bettercrashes.gui.common.failed=[失败]
+#bettercrashes.gui.common.gtnhIssueTracker=Open GTNH issue tracker
 
-bettercrashes.crashscreen.title=Minecraft崩溃啦！
-bettercrashes.crashscreen.summary=Minecraft遇到了一个问题并崩溃了。
-bettercrashes.crashscreen.paragraph1.line1=下列模组被认为可能是导致崩溃的原因：
-bettercrashes.crashscreen.paragraph2.line1=一份报告已经生成，点击下方的按钮可以打开它：
-bettercrashes.crashscreen.paragraph3.line1=我们建议您将此报告的链接发送给模组的作者以帮助它们修复问题，
-bettercrashes.crashscreen.paragraph3.line2=点击"上传并复制链接"即可上传报告并复制它的链接至剪贴板。
-bettercrashes.crashscreen.paragraph3.line3=由于安装了BetterCrashes，尽管发生了崩溃，你仍然可以继续进行游戏。
-bettercrashes.crashscreen.paragraph3.line4=
+bettercrashes.gui.common.paragraph1=下列模组被认为可能是导致崩溃的原因：
+bettercrashes.gui.common.identificationErrored=[鉴别错误]
+bettercrashes.gui.common.unknownCause=未知
+bettercrashes.gui.common.paragraph2=一份报告已经生成，点击下方的按钮可以打开它：
+#bettercrashes.gui.common.reportSaveFailed=[Error saving report, see log]
+bettercrashes.gui.common.paragraph3=我们建议您将此报告的链接发送给模组的作者以帮助它们修复问题，点击"上传并复制链接"即可上传报告并复制它的链接至剪贴板。由于安装了BetterCrashes，尽管发生了崩溃，你仍然可以继续进行游戏。
+#bettercrashes.gui.common.paragraph3_gtnh=You're encouraged to send this report's link to the GTNH issue tracker to help us fix the issue, AFTER searching the tracker for similar issue already reported. Clicking the "Upload and Copy link" button can upload report and copy its link to clipboard. Since BetterCrashes is installed, you can keep playing despite the crash.
+#bettercrashes.gui.common.paragraph4_gtnh=GTNH does not support the following mod(s):
+#bettercrashes.gui.common.paragraph5_gtnh=When sending report, add mention to these as well.
 
-bettercrashes.initerrorscreen.title=Minecraft未能启动!
-bettercrashes.initerrorscreen.summary=启动过程中的一个错误阻止了Minecraft的启动
-bettercrashes.initerrorscreen.paragraph2.line1=一份报告已经生成，点击下方的按钮可以打开它：
-bettercrashes.initerrorscreen.paragraph3.line1=我们建议您将此报告的链接发送给模组的作者以帮助它们修复问题，
-bettercrashes.initerrorscreen.paragraph3.line2=点击"上传并复制链接"即可上传报告并复制它的链接至剪贴板。
-bettercrashes.initerrorscreen.paragraph3.line3=由于安装了BetterCrashes，尽管发生了崩溃，你仍然可以继续进行游戏。
-bettercrashes.initerrorscreen.paragraph3.line4=
+bettercrashes.gui.crash.title=Minecraft崩溃啦！
+bettercrashes.gui.crash.summary=Minecraft遇到了一个问题并崩溃了。
+
+bettercrashes.gui.init_error.title=Minecraft未能启动!
+bettercrashes.gui.init_error.summary=启动过程中的一个错误阻止了Minecraft的启动
 


### PR DESCRIPTION
Add config switch to show GTNH related contents, which mention for GTNH issue tracker and add link for it
Deduplicate some descriptions
Use `listFormattedStringToWidth` to show long descriptions so that line numbers don't depend on language
<img width="960" alt="bettercrashes2" src="https://user-images.githubusercontent.com/40035906/179794871-7b709106-8cd0-45b3-a223-073bced40153.PNG">
