### PR TITLE
Add some cache to avoid making things worse and masking the issue.

### DIFF
--- a/src/main/java/vfyjxf/bettercrashes/utils/ModIdentifier.java
+++ b/src/main/java/vfyjxf/bettercrashes/utils/ModIdentifier.java
@@ -89,20 +89,22 @@ public final class ModIdentifier {
     private static Map<File, Set<ModContainer>> makeModMap() {
         if (cachedModMap != null) return cachedModMap;
         Map<File, Set<ModContainer>> modMap = new HashMap<>();
-        for (ModContainer mod : Loader.instance().getModList()) {
-            Set<ModContainer> currentMods = modMap.getOrDefault(mod.getSource(), new HashSet<>());
+        Map<String, ModContainer> indexedModList = Loader.instance().getIndexedModList();
+
+        ModContainer mc = Loader.instance().getMinecraftModContainer(); // Ignore minecraft jar (minecraft)
+        ModContainer fml = Loader.instance().getIndexedModList().get("FML"); // Ignore forge jar (FML,forge)
+
+        for (ModContainer mod : indexedModList.values()) {
+            // Workaround for https://github.com/MinecraftForge/MinecraftForge/issues/4919
+            if (mod.equals(fml) || mod.equals(mc)) continue;
+
+            Set<ModContainer> currentMods = new HashSet<>();
             currentMods.add(mod);
             try {
                 modMap.put(mod.getSource().getCanonicalFile(), currentMods);
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
-        }
-        try {
-            modMap.remove(Loader.instance().getMinecraftModContainer().getSource()); // Ignore minecraft jar (minecraft)
-            modMap.remove(Loader.instance().getIndexedModList().get("FML").getSource()); // Ignore forge jar (FML,forge)
-        } catch (NullPointerException ignored) {
-            // Workaround for https://github.com/MinecraftForge/MinecraftForge/issues/4919
         }
         cachedModMap = Collections.unmodifiableMap(modMap);
         return cachedModMap;

--- a/src/main/java/vfyjxf/bettercrashes/utils/ModIdentifier.java
+++ b/src/main/java/vfyjxf/bettercrashes/utils/ModIdentifier.java
@@ -99,10 +99,8 @@ public final class ModIdentifier {
             }
         }
         try {
-            // Ignore minecraft jar (minecraft)
-            modMap.remove(Loader.instance().getMinecraftModContainer().getSource());
-            // Ignore forge jar (FML,forge)
-            modMap.remove(Loader.instance().getIndexedModList().get("FML").getSource());
+            modMap.remove(Loader.instance().getMinecraftModContainer().getSource()); // Ignore minecraft jar (minecraft)
+            modMap.remove(Loader.instance().getIndexedModList().get("FML").getSource()); // Ignore forge jar (FML,forge)
         } catch (NullPointerException ignored) {
             // Workaround for https://github.com/MinecraftForge/MinecraftForge/issues/4919
         }

--- a/src/main/java/vfyjxf/bettercrashes/utils/ModIdentifier.java
+++ b/src/main/java/vfyjxf/bettercrashes/utils/ModIdentifier.java
@@ -56,19 +56,15 @@ public final class ModIdentifier {
         return mods;
     }
 
-    public static Set<ModContainer> identifyFromClass(String className) {
-        return identifyFromClass(className, makeModMap());
-    }
-
     private static Set<ModContainer> identifyFromClass(String className, Map<File, Set<ModContainer>> modMap) {
         // Skip identification for Mixin, one's mod copy of the library is shared with all other mods
         if (className.startsWith("org.spongepowered.asm.mixin.")) return Collections.emptySet();
 
         // Get the URL of the class
-        final String untrasformedName = untransformName(Launch.classLoader, className);
-        URL url = Launch.classLoader.getResource(untrasformedName.replace('.', '/') + ".class");
+        final String untransformedName = untransformName(Launch.classLoader, className);
+        URL url = Launch.classLoader.getResource(untransformedName.replace('.', '/') + ".class");
         if (url == null) {
-            log.warn("Failed to identify " + className + " (untransformed name: " + untrasformedName + ")");
+            log.warn("Failed to identify " + className + " (untransformed name: " + untransformedName + ")");
             return Collections.emptySet();
         }
 
@@ -88,7 +84,10 @@ public final class ModIdentifier {
         return Collections.emptySet();
     }
 
+    private static Map<File, Set<ModContainer>> cachedModMap = null;
+
     private static Map<File, Set<ModContainer>> makeModMap() {
+        if (cachedModMap != null) return cachedModMap;
         Map<File, Set<ModContainer>> modMap = new HashMap<>();
         for (ModContainer mod : Loader.instance().getModList()) {
             Set<ModContainer> currentMods = modMap.getOrDefault(mod.getSource(), new HashSet<>());
@@ -99,22 +98,26 @@ public final class ModIdentifier {
                 throw new RuntimeException(e);
             }
         }
-
         try {
-            modMap.remove(Loader.instance().getMinecraftModContainer().getSource()); // Ignore minecraft jar (minecraft)
-            modMap.remove(Loader.instance().getIndexedModList().get("FML").getSource()); // Ignore forge jar (FML,
-            // forge)
+            // Ignore minecraft jar (minecraft)
+            modMap.remove(Loader.instance().getMinecraftModContainer().getSource());
+            // Ignore forge jar (FML,forge)
+            modMap.remove(Loader.instance().getIndexedModList().get("FML").getSource());
         } catch (NullPointerException ignored) {
             // Workaround for https://github.com/MinecraftForge/MinecraftForge/issues/4919
         }
-
-        return modMap;
+        cachedModMap = Collections.unmodifiableMap(modMap);
+        return cachedModMap;
     }
+
+    private static Method untransformNameMethod = null;
 
     private static String untransformName(LaunchClassLoader launchClassLoader, String className) {
         try {
-            Method untransformNameMethod = LaunchClassLoader.class.getDeclaredMethod("untransformName", String.class);
-            untransformNameMethod.setAccessible(true);
+            if (untransformNameMethod == null) {
+                untransformNameMethod = LaunchClassLoader.class.getDeclaredMethod("untransformName", String.class);
+                untransformNameMethod.setAccessible(true);
+            }
             return (String) untransformNameMethod.invoke(launchClassLoader, className);
         } catch (ReflectiveOperationException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
Related to behaviour seen in https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24655 where BetterCrashes end up generating more noise than the actual issue and turning into WorseCrashes.

it had a cache to the makeModMap and untransformName method to stop the whole thing from freaking out.

Tested on full pack on the issue mentioned and it still only print it once but now without the extra impact.


Also removed an unused method and a typo