### PR TITLE
fix mod list overflow on crash screen

### DIFF
--- a/src/main/java/vfyjxf/bettercrashes/utils/GuiCrashScreen.java
+++ b/src/main/java/vfyjxf/bettercrashes/utils/GuiCrashScreen.java
@@ -25,12 +25,10 @@ public class GuiCrashScreen extends GuiProblemScreen {
     @Override
     public void initGui() {
         super.initGui();
-        int extraLines = fontRendererObj.listFormattedStringToWidth(getModListString(), 310).size() - 1;
-        int buttonY = height / 4 + 120 + 12 + extraLines * 9;
         GuiOptionButton mainMenuButton = new GuiOptionButton(
                 0,
                 width / 2 - 50 - 115,
-                buttonY,
+                getButtonY(),
                 110,
                 20,
                 I18n.format("bettercrashes.gui.crash.toTitle"));

--- a/src/main/java/vfyjxf/bettercrashes/utils/GuiCrashScreen.java
+++ b/src/main/java/vfyjxf/bettercrashes/utils/GuiCrashScreen.java
@@ -25,10 +25,12 @@ public class GuiCrashScreen extends GuiProblemScreen {
     @Override
     public void initGui() {
         super.initGui();
+        int extraLines = fontRendererObj.listFormattedStringToWidth(getModListString(), 310).size() - 1;
+        int buttonY = height / 4 + 120 + 12 + extraLines * 9;
         GuiOptionButton mainMenuButton = new GuiOptionButton(
                 0,
                 width / 2 - 50 - 115,
-                height / 4 + 120 + 12,
+                buttonY,
                 110,
                 20,
                 I18n.format("bettercrashes.gui.crash.toTitle"));

--- a/src/main/java/vfyjxf/bettercrashes/utils/GuiProblemScreen.java
+++ b/src/main/java/vfyjxf/bettercrashes/utils/GuiProblemScreen.java
@@ -48,11 +48,13 @@ public abstract class GuiProblemScreen extends GuiScreen {
     public void initGui() {
         mc.setIngameNotInFocus();
         buttonList.clear();
+        int extraLines = fontRendererObj.listFormattedStringToWidth(getModListString(), 310).size() - 1;
+        int buttonY = height / 4 + 120 + 12 + extraLines * 9;
         buttonList.add(
                 new GuiButton(
                         1,
                         width / 2 - 50,
-                        height / 4 + 120 + 12,
+                        buttonY,
                         110,
                         20,
                         I18n.format("bettercrashes.gui.common.openCrashReport")));
@@ -60,7 +62,7 @@ public abstract class GuiProblemScreen extends GuiScreen {
                 new GuiButton(
                         2,
                         width / 2 - 50 + 115,
-                        height / 4 + 120 + 12,
+                        buttonY,
                         110,
                         20,
                         I18n.format("bettercrashes.gui.common.uploadReportAndCopyLink")));
@@ -69,7 +71,7 @@ public abstract class GuiProblemScreen extends GuiScreen {
                     new GuiButton(
                             3,
                             width / 2 - 50 - 15,
-                            height / 4 + 120 + 12 + 25,
+                            buttonY + 25,
                             140,
                             20,
                             I18n.format("bettercrashes.gui.common.issueTracker")));
@@ -159,7 +161,8 @@ public abstract class GuiProblemScreen extends GuiScreen {
         drawString(fontRendererObj, getScreenSummary(), x, y, textColor);
         drawString(fontRendererObj, I18n.format("bettercrashes.gui.common.paragraph1"), x, y += 18, textColor);
 
-        drawCenteredString(fontRendererObj, getModListString(), width / 2, y += 11, 0xE0E000);
+        y += 11;
+        y += drawCenteredLongString(fontRendererObj, getModListString(), y, 310, 0xE0E000);
 
         if (isCrashLogExpectedToBeGenerated()) {
             drawString(fontRendererObj, I18n.format("bettercrashes.gui.common.paragraph2"), x, y += 11, textColor);
@@ -181,11 +184,12 @@ public abstract class GuiProblemScreen extends GuiScreen {
 
         if (hasUnsupportedMods) {
             drawString(fontRendererObj, I18n.format("bettercrashes.gui.common.paragraph4"), x, y += 10, textColor);
-            drawCenteredString(
+            y += 11;
+            y += drawCenteredLongString(
                     fontRendererObj,
                     StringUtils.join(detectedUnsupportedModNames, ", "),
-                    width / 2,
-                    y += 11,
+                    y,
+                    310,
                     0xE0E000);
             drawString(fontRendererObj, I18n.format("bettercrashes.gui.common.paragraph5"), x, y += 12, textColor);
         }
@@ -210,6 +214,15 @@ public abstract class GuiProblemScreen extends GuiScreen {
             }
         }
         return modListString;
+    }
+
+    protected int drawCenteredLongString(FontRenderer fontRenderer, String text, int y, int maxWidth, int color) {
+        int yOffset = 0;
+        for (Object line : Minecraft.getMinecraft().fontRenderer.listFormattedStringToWidth(text, maxWidth)) {
+            drawCenteredString(fontRenderer, (String) line, width / 2, y + yOffset, color);
+            yOffset += 9;
+        }
+        return yOffset;
     }
 
     protected int drawLongString(FontRenderer fontRenderer, String text, int x, int y, int width, int color) {

--- a/src/main/java/vfyjxf/bettercrashes/utils/GuiProblemScreen.java
+++ b/src/main/java/vfyjxf/bettercrashes/utils/GuiProblemScreen.java
@@ -38,6 +38,7 @@ public abstract class GuiProblemScreen extends GuiScreen {
     protected final CrashReport report;
     private volatile URL pasteLink = null;
     private String modListString;
+    private List<String> modListLines;
     protected List<String> detectedUnsupportedModNames;
 
     public GuiProblemScreen(CrashReport report) {
@@ -48,8 +49,7 @@ public abstract class GuiProblemScreen extends GuiScreen {
     public void initGui() {
         mc.setIngameNotInFocus();
         buttonList.clear();
-        int extraLines = fontRendererObj.listFormattedStringToWidth(getModListString(), 310).size() - 1;
-        int buttonY = height / 4 + 120 + 12 + extraLines * 9;
+        int buttonY = getButtonY();
         buttonList.add(
                 new GuiButton(
                         1,
@@ -216,6 +216,17 @@ public abstract class GuiProblemScreen extends GuiScreen {
         return modListString;
     }
 
+    protected List<String> getModListLines() {
+        if (modListLines == null) {
+            modListLines = fontRendererObj.listFormattedStringToWidth(getModListString(), 310);
+        }
+        return modListLines;
+    }
+
+    protected int getButtonY() {
+        return height / 4 + 120 + 12 + (getModListLines().size() - 1) * fontRendererObj.FONT_HEIGHT;
+    }
+
     protected int drawCenteredLongString(FontRenderer fontRenderer, String text, int y, int maxWidth, int color) {
         int yOffset = 0;
         for (String line : fontRenderer.listFormattedStringToWidth(text, maxWidth)) {
@@ -229,7 +240,7 @@ public abstract class GuiProblemScreen extends GuiScreen {
         int yOffset = 0;
         for (String line : fontRenderer.listFormattedStringToWidth(text, width)) {
             drawString(fontRenderer, line, x, y + yOffset, color);
-            yOffset += 9;
+            yOffset += fontRenderer.FONT_HEIGHT;
         }
         return yOffset;
     }

--- a/src/main/java/vfyjxf/bettercrashes/utils/GuiProblemScreen.java
+++ b/src/main/java/vfyjxf/bettercrashes/utils/GuiProblemScreen.java
@@ -220,7 +220,7 @@ public abstract class GuiProblemScreen extends GuiScreen {
         int yOffset = 0;
         for (String line : fontRenderer.listFormattedStringToWidth(text, maxWidth)) {
             drawCenteredString(fontRenderer, line, width / 2, y + yOffset, color);
-            yOffset += 9;
+            yOffset += fontRenderer.FONT_HEIGHT;
         }
         return yOffset;
     }

--- a/src/main/java/vfyjxf/bettercrashes/utils/GuiProblemScreen.java
+++ b/src/main/java/vfyjxf/bettercrashes/utils/GuiProblemScreen.java
@@ -218,8 +218,8 @@ public abstract class GuiProblemScreen extends GuiScreen {
 
     protected int drawCenteredLongString(FontRenderer fontRenderer, String text, int y, int maxWidth, int color) {
         int yOffset = 0;
-        for (Object line : Minecraft.getMinecraft().fontRenderer.listFormattedStringToWidth(text, maxWidth)) {
-            drawCenteredString(fontRenderer, (String) line, width / 2, y + yOffset, color);
+        for (String line : fontRenderer.listFormattedStringToWidth(text, maxWidth)) {
+            drawCenteredString(fontRenderer, line, width / 2, y + yOffset, color);
             yOffset += 9;
         }
         return yOffset;
@@ -227,8 +227,8 @@ public abstract class GuiProblemScreen extends GuiScreen {
 
     protected int drawLongString(FontRenderer fontRenderer, String text, int x, int y, int width, int color) {
         int yOffset = 0;
-        for (Object line : Minecraft.getMinecraft().fontRenderer.listFormattedStringToWidth(text, width)) {
-            drawString(fontRenderer, (String) line, x, y + yOffset, color);
+        for (String line : fontRenderer.listFormattedStringToWidth(text, width)) {
+            drawString(fontRenderer, line, x, y + yOffset, color);
             yOffset += 9;
         }
         return yOffset;


### PR DESCRIPTION
The list of suspected mods was rendered as a single line via drawCenteredString, causing it to overflow the screen when many mods were listed. Fixed by wrapping the text to 310px width and making button positions dynamic to account for extra lines.

|Before|After|
|-|-|
|<img width="2560" height="1369" alt="java_iWlYLhBcn4" src="https://github.com/user-attachments/assets/1c67c570-3af1-492d-848a-8b40629d1b67" />|<img width="2560" height="1369" alt="java_J5TlBVZjFt" src="https://github.com/user-attachments/assets/0e8d4fd4-221e-4fae-ae1e-bd52633f9b04" />| 