### PR TITLE
catch format errors in item display names instead of crashing

### DIFF
--- a/src/main/java/vfyjxf/bettercrashes/mixins/MixinPlugin.java
+++ b/src/main/java/vfyjxf/bettercrashes/mixins/MixinPlugin.java
@@ -45,10 +45,10 @@ public class MixinPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader {
     @Override
     public List<String> getMixins(Set<String> loadedCoreMods) {
         final List<String> mixins = new ArrayList<>();
+        mixins.add("ItemStackMixin");
         if (FMLLaunchHandler.side().isClient()) {
             mixins.add("CrashReportMixin");
             mixins.add("MinecraftMixin");
-            mixins.add("ItemStackMixin");
         }
         return mixins;
     }

--- a/src/main/java/vfyjxf/bettercrashes/mixins/MixinPlugin.java
+++ b/src/main/java/vfyjxf/bettercrashes/mixins/MixinPlugin.java
@@ -48,6 +48,7 @@ public class MixinPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader {
         if (FMLLaunchHandler.side().isClient()) {
             mixins.add("CrashReportMixin");
             mixins.add("MinecraftMixin");
+            mixins.add("ItemStackMixin");
         }
         return mixins;
     }

--- a/src/main/java/vfyjxf/bettercrashes/mixins/early/ItemStackMixin.java
+++ b/src/main/java/vfyjxf/bettercrashes/mixins/early/ItemStackMixin.java
@@ -1,17 +1,18 @@
 package vfyjxf.bettercrashes.mixins.early;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.IllegalFormatException;
+import java.util.Set;
+
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
-import vfyjxf.bettercrashes.BetterCrashes;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.IllegalFormatException;
-import java.util.Set;
+import vfyjxf.bettercrashes.BetterCrashes;
 
 @Mixin(ItemStack.class)
 public abstract class ItemStackMixin {

--- a/src/main/java/vfyjxf/bettercrashes/mixins/early/ItemStackMixin.java
+++ b/src/main/java/vfyjxf/bettercrashes/mixins/early/ItemStackMixin.java
@@ -24,7 +24,7 @@ public abstract class ItemStackMixin {
             return item.getItemStackDisplayName(stack);
         } catch (Exception e) {
             String unlocalizedName = item.getUnlocalizedName(stack);
-            LOGGER.warn("Format error in display name for item '{}': {}", unlocalizedName, e.getMessage());
+            LOGGER.error("Format error in display name for item '{}'", unlocalizedName, e);
             return unlocalizedName + " [FORMAT ERROR]";
         }
     }

--- a/src/main/java/vfyjxf/bettercrashes/mixins/early/ItemStackMixin.java
+++ b/src/main/java/vfyjxf/bettercrashes/mixins/early/ItemStackMixin.java
@@ -1,0 +1,31 @@
+package vfyjxf.bettercrashes.mixins.early;
+
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(ItemStack.class)
+public abstract class ItemStackMixin {
+
+    private static final Logger LOGGER = LogManager.getLogger("BetterCrashes");
+
+    @Redirect(
+            method = "getDisplayName",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/item/Item;getItemStackDisplayName(Lnet/minecraft/item/ItemStack;)Ljava/lang/String;"))
+    private String betterCrashes$safeGetDisplayName(Item item, ItemStack stack) {
+        try {
+            return item.getItemStackDisplayName(stack);
+        } catch (Exception e) {
+            String unlocalizedName = item.getUnlocalizedName(stack);
+            LOGGER.warn("Format error in display name for item '{}': {}", unlocalizedName, e.getMessage());
+            return unlocalizedName + " [FORMAT ERROR]";
+        }
+    }
+}

--- a/src/main/java/vfyjxf/bettercrashes/mixins/early/ItemStackMixin.java
+++ b/src/main/java/vfyjxf/bettercrashes/mixins/early/ItemStackMixin.java
@@ -3,16 +3,20 @@ package vfyjxf.bettercrashes.mixins.early;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
+import vfyjxf.bettercrashes.BetterCrashes;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.IllegalFormatException;
+import java.util.Set;
 
 @Mixin(ItemStack.class)
 public abstract class ItemStackMixin {
 
-    private static final Logger LOGGER = LogManager.getLogger("BetterCrashes");
+    private static final Set<Item> BROKEN_ITEMS = Collections.synchronizedSet(new HashSet<>());
 
     @Redirect(
             method = "getDisplayName",
@@ -22,9 +26,16 @@ public abstract class ItemStackMixin {
     private String betterCrashes$safeGetDisplayName(Item item, ItemStack stack) {
         try {
             return item.getItemStackDisplayName(stack);
-        } catch (Exception e) {
-            String unlocalizedName = item.getUnlocalizedName(stack);
-            LOGGER.error("Format error in display name for item '{}'", unlocalizedName, e);
+        } catch (IllegalFormatException e) {
+            String unlocalizedName;
+            try {
+                unlocalizedName = item.getUnlocalizedName(stack);
+            } catch (IllegalFormatException ex2) {
+                unlocalizedName = item.getClass().getSimpleName();
+            }
+            if (BROKEN_ITEMS.add(item)) {
+                BetterCrashes.logger.error("Format error in display name for item '{}'", unlocalizedName, e);
+            }
             return unlocalizedName + " [FORMAT ERROR]";
         }
     }


### PR DESCRIPTION
items with broken translation format specifiers (e.g. %materials instead of %s) threw UnknownFormatConversionException on tooltip hover and crashed the game, fixed by adding ItemStackMixin that catches IllegalFormatException from getItemStackDisplayName and returns the unlocalized name with [FORMAT ERROR] suffix so the item is still visible and an error with the item key is logged for debugging

<img width="556" height="128" alt="image" src="https://github.com/user-attachments/assets/97c98d03-94ae-4f89-ba9d-07768f55be66" />