### PR TITLE
Modernize: enable jabel, generic injection, Tags class

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -44,7 +44,7 @@ developmentEnvironmentUserName = Developer
 # - jabel: Jabel syntax-only support, compiles to J8 bytecode
 # - jvmDowngrader: Full modern Java via JVM Downgrader (syntax + stdlib APIs)
 # - modern: Native modern Java bytecode, no downgrading
-enableModernJavaSyntax = false
+enableModernJavaSyntax = jabel
 
 # If set, ignores the above setting and compiles with the given toolchain. This may cause unexpected issues,
 # and should *not* be used in most situations. -1 disables this.
@@ -69,24 +69,24 @@ enableModernJavaSyntax = false
 
 # Enables injecting missing generics into the decompiled source code for a better coding experience.
 # Turns most publicly visible List, Map, etc. into proper List<E>, Map<K, V> types.
-enableGenericInjection = false
+enableGenericInjection = true
 
 # Generate a class with a String field for the mod version named as defined below.
 # If generateGradleTokenClass is empty or not missing, no such class will be generated.
 # If gradleTokenVersion is empty or missing, the field will not be present in the class.
-generateGradleTokenClass =
+generateGradleTokenClass = vfyjxf.bettercrashes.Tags
 
 # Name of the token containing the project's current version to generate/replace.
-gradleTokenVersion = GRADLETOKEN_VERSION
+gradleTokenVersion = VERSION
 
 # [DEPRECATED] Mod ID replacement token.
-gradleTokenModId = GRADLETOKEN_MODID
+gradleTokenModId =
 
 # [DEPRECATED] Mod name replacement token.
-gradleTokenModName = GRADLETOKEN_MODNAME
+gradleTokenModName =
 
 # [DEPRECATED] Mod Group replacement token.
-gradleTokenGroupName = GRADLETOKEN_GROUPNAME
+gradleTokenGroupName =
 
 # [DEPRECATED]
 # Multiple source files can be defined here by providing a comma-separated list: Class1.java,Class2.java,Class3.java
@@ -94,7 +94,7 @@ gradleTokenGroupName = GRADLETOKEN_GROUPNAME
 # The string's content will be replaced with your mod's version when compiled. You should use this to specify your mod's
 # version in @Mod([...], version = VERSION, [...]).
 # Leave these properties empty to skip individual token replacements.
-replaceGradleTokenInFile = BetterCrashes.java
+replaceGradleTokenInFile =
 
 # In case your mod provides an API for other mods to implement you may declare its package here. Otherwise, you can
 # leave this property empty.

--- a/src/main/java/vfyjxf/bettercrashes/BetterCrashes.java
+++ b/src/main/java/vfyjxf/bettercrashes/BetterCrashes.java
@@ -8,12 +8,11 @@ import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.relauncher.Side;
 
-@Mod(modid = BetterCrashes.MODID, version = BetterCrashes.VERSION, name = BetterCrashes.NAME)
+@Mod(modid = BetterCrashes.MODID, version = Tags.VERSION, name = BetterCrashes.NAME)
 public class BetterCrashes {
 
-    public static final String MODID = "GRADLETOKEN_MODID";
-    public static final String NAME = "GRADLETOKEN_MODNAME";
-    public static final String VERSION = "GRADLETOKEN_VERSION";
+    public static final String MODID = "bettercrashes";
+    public static final String NAME = "BetterCrashes";
     public static final Logger logger = LogManager.getLogger(NAME);
 
     @Mod.EventHandler

--- a/src/main/java/vfyjxf/bettercrashes/mixins/early/MinecraftMixin.java
+++ b/src/main/java/vfyjxf/bettercrashes/mixins/early/MinecraftMixin.java
@@ -7,6 +7,7 @@
 package vfyjxf.bettercrashes.mixins.early;
 
 import java.util.Queue;
+import java.util.concurrent.FutureTask;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.audio.SoundHandler;
@@ -74,7 +75,7 @@ public abstract class MinecraftMixin implements MinecraftExt {
 
     @Shadow
     @Final
-    private Queue field_152351_aB; // field_152351_aB --> scheduledTasks
+    private Queue<FutureTask<?>> field_152351_aB; // field_152351_aB --> scheduledTasks
 
     @Shadow
     public EntityRenderer entityRenderer;

--- a/src/main/java/vfyjxf/bettercrashes/utils/HttpUtils.java
+++ b/src/main/java/vfyjxf/bettercrashes/utils/HttpUtils.java
@@ -1,7 +1,7 @@
 package vfyjxf.bettercrashes.utils;
 
 import static vfyjxf.bettercrashes.BetterCrashes.NAME;
-import static vfyjxf.bettercrashes.BetterCrashes.VERSION;
+import static vfyjxf.bettercrashes.Tags.VERSION;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;


### PR DESCRIPTION
enableModernJavaSyntax was false and enableGenericInjection was disabled, preventing modern syntax and properly-typed MC APIs. Switched enableModernJavaSyntax to jabel, enabled generic injection, migrated from the deprecated replaceGradleTokenInFile to generateGradleTokenClass (produces vfyjxf.bettercrashes.Tags), cleared deprecated gradleToken* fields, and typed the one raw Queue shadow in MinecraftMixin as Queue<FutureTask<?>>. Needs to land before the error-display fix PR.